### PR TITLE
 Improve pretty-print formatting of negative amount of money

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -72,6 +72,7 @@ $config = PhpCsFixer\Config::create()
         'standardize_not_equals' => true,
         'strict_comparison' => true,
         'strict_param' => true,
+        'ternary_operator_spaces' => true,
         'ternary_to_null_coalescing' => true,
         'trailing_comma_in_multiline_array' => true,
         'trim_array_spaces' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Security - in case of vulnerabilities.
 
 _TBD_
 
+## 1.0.1 (2019-03-05)
+
+### Fixed
++ Fixed pretty-print formatting of negative amount of money
+
 ## 1.0.0 (2018-12-08)
 
 Initial Release

--- a/src/Money.php
+++ b/src/Money.php
@@ -165,7 +165,11 @@ final class Money implements JsonSerializable
      */
     public function getPrettyPrint(string $decimalPoint = '.', string $thousandsSeparator = ','): string
     {
-        return $this->getCurrency()->getSign() . $this->getFormattedAmount($decimalPoint, $thousandsSeparator);
+        $currencySign = $this->getCurrency()->getSign();
+        $formattedAmount = ltrim($this->getFormattedAmount($decimalPoint, $thousandsSeparator), '-');
+        $amountSign = $this->isNegative() ? '-':'';
+
+        return "{$amountSign}{$currencySign}{$formattedAmount}";
     }
 
     /**

--- a/src/Money.php
+++ b/src/Money.php
@@ -167,7 +167,7 @@ final class Money implements JsonSerializable
     {
         $currencySign = $this->getCurrency()->getSign();
         $formattedAmount = ltrim($this->getFormattedAmount($decimalPoint, $thousandsSeparator), '-');
-        $amountSign = $this->isNegative() ? '-':'';
+        $amountSign = $this->isNegative() ? '-' : '';
 
         return "{$amountSign}{$currencySign}{$formattedAmount}";
     }

--- a/tests/Exchange/RateTest.php
+++ b/tests/Exchange/RateTest.php
@@ -15,13 +15,13 @@ class RateTest extends TestCase
     {
         $cp = new CurrencyPair(new Currency('USD'), new Currency('EUR'));
         $this->expectException(InvalidArgumentException::class);
-        new Rate($cp, new DateTime(), 0);
+        new Rate($cp, $this->getRateDate(), 0);
     }
 
     public function testCanBeConstructed()
     {
         $cp = new CurrencyPair(new Currency('USD'), new Currency('EUR'));
-        $rate = new Rate($cp, new DateTime(), 0.92);
+        $rate = new Rate($cp, $this->getRateDate(), 0.92);
 
         $this->assertInstanceOf(Rate::class, $rate);
 
@@ -36,7 +36,7 @@ class RateTest extends TestCase
     public function testCanBeSerialized(Rate $rate): void
     {
         $this->assertSame(
-            '{"baseCurrency":"USD","quoteCurrency":"EUR","date":"' . date('c') . '","ratio":0.92}',
+            '{"baseCurrency":"USD","quoteCurrency":"EUR","date":"' . $this->getRateDate()->format('c') . '","ratio":0.92}',
             json_encode($rate)
         );
     }
@@ -111,5 +111,10 @@ class RateTest extends TestCase
         // the straight conversion without markup is EUR 9.20
         $this->assertSame(966, $newMoney->getAmount());
         $this->assertSame('EUR', $newMoney->getCurrency()->getCurrencyCode());
+    }
+
+    private function getRateDate(): DateTime
+    {
+        return new DateTime('2019-03-05 13:32');
     }
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -113,6 +113,13 @@ class MoneyTest extends TestCase
         $this->assertSame('€1,200.34', $m->getPrettyPrint('.', ','));
     }
 
+    public function testFormattedNegativeAmountCanBeRetrieved(): void
+    {
+        $m = new Money(-120034, new Currency('EUR'));
+        $this->assertSame('-1 200.34', $m->getFormattedAmount('.', ' '));
+        $this->assertSame('-€1,200.34', $m->getPrettyPrint('.', ','));
+    }
+
     /**
      * @depends testObjectCanBeConstructedFromIntegerValueAndCurrencyObject
      *


### PR DESCRIPTION
This pull request fixes pretty-print formatting for negative amount of money.

Now It formats ```-39.95 USD``` as ```-$39.95``` instead of ```$-39.95```