### PR TITLE
Add `$withCurrencyCode` parameter to render amount of money with currency code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Security - in case of vulnerabilities.
 
 ## [Unreleased]
 
-## 2.0.1 (2024-02-29)
+## 2.1.0 (2024-02-29)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Security - in case of vulnerabilities.
 
 ## [Unreleased]
 
+## 2.0.1 (2024-02-29)
+
+### Changed
+
++ Added `$withCurrencyCode` parameter to `Money::prettyPrint()` to render amount of money with currency code.
+
 ## 2.0.0 (2022-02-09)
 
 ### Changed

--- a/src/Money.php
+++ b/src/Money.php
@@ -164,16 +164,21 @@ final class Money implements JsonSerializable
      *
      * @param string $decimalPoint
      * @param string $thousandsSeparator
+     * @param bool $withCurrencyCode
      *
      * @return string
      */
-    public function getPrettyPrint(string $decimalPoint = '.', string $thousandsSeparator = ','): string
-    {
+    public function getPrettyPrint(
+        string $decimalPoint = '.',
+        string $thousandsSeparator = ',',
+        bool $withCurrencyCode = false
+    ): string {
         $currencySign = $this->getCurrency()->getSign();
         $formattedAmount = ltrim($this->getFormattedAmount($decimalPoint, $thousandsSeparator), '-');
         $amountSign = $this->isNegative() ? '-' : '';
+        $currencyCode = $withCurrencyCode ? " {$this->getCurrency()->getCurrencyCode()}" : '';
 
-        return "{$amountSign}{$currencySign}{$formattedAmount}";
+        return "{$amountSign}{$currencySign}{$formattedAmount}{$currencyCode}";
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -143,6 +143,15 @@ class MoneyTest extends TestCase
         self::assertSame('-€1,200.34', $m->getPrettyPrint('.', ','));
     }
 
+    public function testFormattedAmountCanBeRetrievedWithCurrecyCode(): void
+    {
+        $m = new Money(120034, new Currency('EUR'));
+        self::assertSame(
+            '€1,200.34 EUR',
+            $m->getPrettyPrint('.', ',', true)
+        );
+    }
+
     /**
      * @depends testObjectCanBeConstructedFromIntegerValueAndCurrencyObject
      *


### PR DESCRIPTION
In this PR was added `$withCurrencyCode` parameter to render amount of money with currency code