### PR TITLE
Fix CLF subunit and name

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -282,10 +282,10 @@ final class Currency implements JsonSerializable
             'deprecated' => false,
         ],
         'CLF' => [
-            'display_name' => 'Unidades de fomento',
+            'display_name' => 'Unidad de Fomento',
             'numeric_code' => 990,
-            'default_fraction_digits' => 0,
-            'sub_unit' => 100,
+            'default_fraction_digits' => 4,
+            'sub_unit' => 10000,
             'sign' => 'UF',
             'deprecated' => false,
         ],


### PR DESCRIPTION
The `CLF` currency (Chile) should have four decimal places. It was in our library as having zero. This PR corrects the subunit for CLF and also improves the name. Previously, the name was in the plural, but it should be singular.

<img width="965" alt="Screenshot 2025-04-15 at 2 28 49 PM" src="https://github.com/user-attachments/assets/0c2f2e9c-f301-4bed-98de-eb8b1d8c3987" />

**Context**

https://en.wikipedia.org/wiki/ISO_4217
https://en.wikipedia.org/wiki/Unidad_de_Fomento