### PR TITLE
Deprecate SLL and HRK, add SLE

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -527,7 +527,7 @@ final class Currency implements JsonSerializable
             'default_fraction_digits' => 2,
             'sub_unit' => 100,
             'sign' => 'kn',
-            'deprecated' => false,
+            'deprecated' => true,
         ],
         'HTG' => [
             'display_name' => 'Gourde',
@@ -1089,13 +1089,21 @@ final class Currency implements JsonSerializable
             'sign' => '£',
             'deprecated' => false,
         ],
+        'SLE' => [
+            'display_name' => 'Leone',
+            'numeric_code' => 925,
+            'default_fraction_digits' => 2,
+            'sub_unit' => 100,
+            'sign' => 'Le',
+            'deprecated' => false,
+        ],
         'SLL' => [
             'display_name' => 'Leone',
             'numeric_code' => 694,
             'default_fraction_digits' => 2,
             'sub_unit' => 100,
             'sign' => 'Le',
-            'deprecated' => false,
+            'deprecated' => true,
         ],
         'SOS' => [
             'display_name' => 'Somali Shilling',


### PR DESCRIPTION
Deprecates `SLL` and `HRK`. `SLL` has not been honored as legal tender since Mar 31, 2024. `HRK` has not been legal tender since 2023.

Adds `SLE`, which replaced `SLL` as currency in Sierra Leone.

https://en.wikipedia.org/wiki/Sierra_Leonean_leone
https://en.wikipedia.org/wiki/Croatian_kuna